### PR TITLE
Update/advance/render now respect system addition order.

### DIFF
--- a/ECSE/World.cpp
+++ b/ECSE/World.cpp
@@ -13,25 +13,25 @@ World::~World()
 
 void World::update(sf::Time deltaTime)
 {
-    for (auto& pair : systems)
+    for (auto& system : systemOrder)
     {
-        pair.second->update(deltaTime);
+        system->update(deltaTime);
     }
 }
 
 void World::advance()
 {
-    for (auto& pair : systems)
+    for (auto& system : systemOrder)
     {
-        pair.second->advance();
+        system->advance();
     }
 }
 
 void World::render(float alpha)
 {
-    for (auto& pair : systems)
+    for (auto& system : systemOrder)
     {
-        pair.second->render(alpha);
+        system->render(alpha);
     }
 }
 

--- a/ECSE/World.h
+++ b/ECSE/World.h
@@ -84,6 +84,8 @@ protected:
 
 private:
     std::map<size_t, std::unique_ptr<System>> systems;  //!< Map from System type hash code to the System itself.
+    std::vector<System*> systemOrder;                   //!< Vector of Systems in preferred call order.
+
 };
 
 /////////////////
@@ -127,8 +129,12 @@ void World::addSystem()
         throw std::runtime_error(ss.str());
     }
 
+    SystemType *system = new SystemType(this);
     size_t hashCode = typeid(SystemType).hash_code();
-    systems[hashCode] = std::unique_ptr<System>(new SystemType(this));
+
+    // Add pointer to map and the vector. Map owns the system while vector has just the pointer
+    systems[hashCode] = std::unique_ptr<System>(system);
+    systemOrder.push_back(system);
 }
 
 template <typename SystemType>


### PR DESCRIPTION
I intentionally made it so registerEntity continues to iterate over the map, I didn't see why it should use the ordered vector. Dunno if that should change.
